### PR TITLE
Reset network interfaces at the end of the PXE boot to allow DHCP to run

### DIFF
--- a/archiso/initcpio/hooks/archiso_pxe_common
+++ b/archiso/initcpio/hooks/archiso_pxe_common
@@ -61,10 +61,11 @@ run_latehook () {
         [[ -z "${copy_resolvconf}" ]] && copy_resolvconf="y"
 
         if [[ "${copytoram}" == "y" ]]; then
-            if [[ -n "${bootif_dev}" ]]; then
-                ip addr flush dev "${bootif_dev}"
-                ip link set "${bootif_dev}" down
-            fi
+            for curif in /sys/class/net/*; do
+                netdev=${curif#/sys/class/net/}
+                ip addr flush dev "${netdev}"
+                ip link set "${netdev}" down
+            done
         elif [[ "${copy_resolvconf}" != "n" && -f /etc/resolv.conf ]]; then
             cp /etc/resolv.conf /new_root/etc/resolv.conf
         fi


### PR DESCRIPTION
The issue is that the interface is not properly de-configured during the boot process when `BOOTIF=xxxx` is not defined in the boot command line because of the condition in `run_latehook`:

```
            if [[ -n "${bootif_dev}" ]]; then
                ip addr flush dev "${bootif_dev}"
                ip link set "${bootif_dev}" down
            fi
```

If `BOOTIF` (and hence `bootif_dev`) is not defined it does not de-configure the network at the end of the PXE boot process. And this causes the DHCP client not to run in the final root file system at the end of the boot process. So the network interfaces still has its address but the /etc/resolv.conf file in the final root file system is not populated.

Adding `SYSAPPEND 3` makes the problem disappear because it makes pxelinux set `BOOTIF` (and `ip=xxx`) automatically. The value is important as 3=1+2 and flag 2 is the one which sets `BOOTIF` (flag 1 sets `ip=xxx`)

I could confirm this is what happens by booting without `SYSAPPEND` and adding `break=postmount` to the boot command line. I then get a shell after the system was downloaded over the network. I could then see the network interface was still configured at this stage. I could manually run the two commands to de-configure it: `ip addr flush dev eth0 ; ip link set eth0 down`. Then I type `exit` and it finishes booting. At then NetworkManager runs a DHCP query and /etc/resolv.conf is updated.

Cf https://gitlab.com/fdupoux/sysresccd-src/-/issues/19 for more details