### PR TITLE
Add grub and refind back

### DIFF
--- a/configs/releng/packages.x86_64
+++ b/configs/releng/packages.x86_64
@@ -34,6 +34,7 @@ gpart
 gpm
 gptfdisk
 grml-zsh-config
+grub
 hdparm
 intel-ucode
 ipw2100-fw
@@ -83,6 +84,7 @@ ppp
 pptpclient
 pv
 qemu-guest-agent
+refind
 reflector
 reiserfsprogs
 rp-pppoe


### PR DESCRIPTION
"rescue/installation actions for {grub,refind} should be run from within a chroot" is a false statement. See --boot-directory of grub-install and --root of refind-install. (In the case of grub, there are people that do not use the ugly grub-mkconfig at all.)